### PR TITLE
new functionality to capture prediction scores from the OpenNMT model

### DIFF
--- a/natas/__init__.py
+++ b/natas/__init__.py
@@ -5,8 +5,8 @@ from .ocr_builder import get_wv_normalization
 class W2VException(Exception):
 	pass
 
-def normalize_words(words, n_best=10, dictionary=None, all_candidates=True, correct_spelling_cache=True):
-	return _normalize(words, "normalization.pt", n_best=n_best, dictionary=dictionary, all_candidates=all_candidates,correct_spelling_cache=correct_spelling_cache)
+def normalize_words(words, n_best=10, dictionary=None, all_candidates=True, correct_spelling_cache=True, return_scores=False):
+	return _normalize(words, "normalization.pt", n_best=n_best, dictionary=dictionary, all_candidates=all_candidates,correct_spelling_cache=correct_spelling_cache, return_scores=return_scores)
 
 def ocr_correct_words(words, n_best=10, dictionary=None, all_candidates=True, hybrid=False, hybrid_w2v_model=None,correct_spelling_cache=True):
 	if hybrid is True and hybrid_w2v_model is None:


### PR DESCRIPTION
This PR adds a new argument to `normalize_words()` to optionally return scores for every candidate word outputted by the model. These scores are outputted by OpenNMT's `Translator`, so the changes only involve capturing this output.

**Summary of changes**

+ Prediction scores are stored in the `fake_stream` class during a translation run and are called from that class after the translations are complete
+ Output of `call_onmt()` is now a list of candidate tuples, where the first position in a tuple is the candidate word and the second is the prediction score
+ Small modification to `_dict_filter()` involves handling the candidate tuples
+ `_normalize()` now ends with an `if/else` check to determine whether the candidate words and their scores should be returned, or just the words